### PR TITLE
Arena v3 change

### DIFF
--- a/src/routes/CollectionPage.tsx
+++ b/src/routes/CollectionPage.tsx
@@ -19,7 +19,7 @@ export default function CollectionPage() {
   return <article>
     <HelmetMeta meta={meta} />
     <PageHeader>
-      <QueryPreservingLink to="/">poppenhuis</QueryPreservingLink> / <QueryPreservingLink to={`/${user.id}`}>{user.name}</QueryPreservingLink> / {collection.name} / <Size ts={collection.items} t="item" />
+        <QueryPreservingLink to="/">poppenhuis</QueryPreservingLink> / <QueryPreservingLink to={`/${user.id}`}>{user.name}</QueryPreservingLink> / {collection.name} / <Size ts={collection.items} t="item" />
     </PageHeader>
     <div className="header-content">
       {(user.source === undefined || user.source === 'firebase') && (

--- a/src/routes/UsersPage.tsx
+++ b/src/routes/UsersPage.tsx
@@ -230,7 +230,7 @@ function ArenaUserLoader() {
   return (
     <>
       <p className="p-spacing">
-        Enter an Are.na profile slug. Only channels whose description includes <code>poppenhu.is</code> will be loaded; add <code>poppenhu.is</code> to a channel&apos;s description on Are.na to include it here.
+        Enter an Are.na profile slug. Only channels whose description includes <code>poppenhu.is</code> will be loaded, and only blocks uploaded as <code>.glb</code> files within those channels will be displayed. 
       </p>
       <p className="p-spacing">
         <label>
@@ -242,15 +242,12 @@ function ArenaUserLoader() {
         }}>Load placeholder user</button>
       </p>
       <p className="p-spacing">
-        The following (shareable!) link will only display channels whose description contains <code>poppenhu.is</code>, and only blocks that are <code>.glb</code> files within those channels:
-      </p>
-      <p className="p-spacing">
         {userSlug ? (
           <NavLink to={{ pathname: `/${userSlug}`, search: `${ARENA_USER_QUERY_PARAM}=${userSlug}` }}>
             {window.location.origin}/{userSlug}?{ARENA_USER_QUERY_PARAM}={userSlug}
           </NavLink>
         ) : (
-          <span>{window.location.origin}</span>
+          <i>NO SLUG</i>
         )}
       </p>
       <p className="p-spacing">

--- a/src/routes/UsersPage.tsx
+++ b/src/routes/UsersPage.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import { Await, useLoaderData, useSearchParams } from "react-router";
+import { Await, useLoaderData, useSearchParams, NavLink } from "react-router";
 import { loadUsers } from "../manifest";
 import type { User } from "../manifest";
-import { MANIFEST_URL_QUERY_PARAM, MANIFEST_SCHEMA, ARENA_PREFIX } from "../manifest";
+import { MANIFEST_URL_QUERY_PARAM, MANIFEST_SCHEMA, ARENA_USER_QUERY_PARAM } from "../manifest";
 import { Size } from '../components/Size';
 import { DEFAULT_META } from "../meta";
 import { HelmetMeta } from "../components/HelmetMeta";
@@ -148,7 +148,6 @@ export default function UsersPage() {
 
 function UserListEntry(props: { user: User }) {
   const { user } = props;
-
   return (
     <li key={user.id}>
       <QueryPreservingLink to={user.id}>{user.name}</QueryPreservingLink> <Size ts={user.collections} t="collection" />
@@ -156,7 +155,7 @@ function UserListEntry(props: { user: User }) {
         {
           user.collections.map((collection) =>
             <li key={collection.id}>
-              <QueryPreservingLink to={user.id + "/" + collection.id}>{collection.name}</QueryPreservingLink> <Size ts={collection.items} t="item" />
+              <QueryPreservingLink to={`${user.id}/${collection.id}`}>{collection.name}</QueryPreservingLink> <Size ts={collection.items} t="item" />
               <div>
                 {collection.items[0] && <ModelViewerWrapper item={collection.items[0]} size="small" />}
               </div>
@@ -231,7 +230,7 @@ function ArenaUserLoader() {
   return (
     <>
       <p className="p-spacing">
-        Enter an Are.na profile slug:
+        Enter an Are.na profile slug. Only channels whose description includes <code>poppenhu.is</code> will be loaded; add <code>poppenhu.is</code> to a channel&apos;s description on Are.na to include it here.
       </p>
       <p className="p-spacing">
         <label>
@@ -243,12 +242,16 @@ function ArenaUserLoader() {
         }}>Load placeholder user</button>
       </p>
       <p className="p-spacing">
-        The following (shareable!) link will only display channels that contain blocks uploaded as <code>.glb</code> files:
+        The following (shareable!) link will only display channels whose description contains <code>poppenhu.is</code>, and only blocks that are <code>.glb</code> files within those channels:
       </p>
       <p className="p-spacing">
-        <QueryPreservingLink to={`/${ARENA_PREFIX}${userSlug}`}>
-          {window.location.origin}/{ARENA_PREFIX}{userSlug}
-        </QueryPreservingLink>
+        {userSlug ? (
+          <NavLink to={{ pathname: `/${userSlug}`, search: `${ARENA_USER_QUERY_PARAM}=${userSlug}` }}>
+            {window.location.origin}/{userSlug}?{ARENA_USER_QUERY_PARAM}={userSlug}
+          </NavLink>
+        ) : (
+          <span>{window.location.origin}</span>
+        )}
       </p>
       <p className="p-spacing">
         You can add structured metadata to your Are.na blocks by including YAML in the description.

--- a/src/routes/UsersPage.tsx
+++ b/src/routes/UsersPage.tsx
@@ -247,7 +247,7 @@ function ArenaUserLoader() {
             {window.location.origin}/{userSlug}?{ARENA_USER_QUERY_PARAM}={userSlug}
           </NavLink>
         ) : (
-          <i>NO SLUG</i>
+          <i>ENTER SLUG ABOVE</i>
         )}
       </p>
       <p className="p-spacing">


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it rewrites the are.na import path and user-loading/routing behavior, which can break external data fetching, pagination, and deep links if assumptions about v3 responses or URL formats are wrong.
> 
> **Overview**
> **Migrates the Are.na integration from v2 to v3.** `loadArenaUser` is rewritten to use v3 endpoints, paginate through user channels and channel contents, and coerce v3 description formats before parsing YAML metadata.
> 
> **Changes how Are.na users are addressed and loaded.** The `arena:` URL prefix is removed; instead, Are.na users are injected via the `?arena=` query param and merged alongside Firebase/manifest users in `loadUsers`/`loadUser`.
> 
> **Updates the homepage loader UI accordingly.** `UsersPage` now generates shareable links like `/{slug}?arena={slug}` (and adds guidance about only loading channels containing `poppenhu.is` and `.glb` blocks), plus minor link formatting cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ad0327160fef2eb1a98749227c013dba62d75f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->