### PR TITLE
Fix Netlify deploy: replace js-yaml in edge function graph

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,19 +10,18 @@
       "dependencies": {
         "@google/model-viewer": "^4.3.1",
         "@types/html2canvas": "^0.5.35",
-        "@types/js-yaml": "^4.0.9",
         "aframe": "^1.7.1",
         "aframe-extras": "^7.6.0",
         "firebase": "^12.6.0",
         "html2canvas": "^1.4.1",
-        "js-yaml": "^4.1.0",
         "jszip": "^3.10.1",
         "qrcode": "^1.5.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-helmet": "^6.1.0",
         "react-markdown": "^9.0.1",
-        "react-router": "^7.1.0"
+        "react-router": "^7.1.0",
+        "yaml": "^2.8.1"
       },
       "devDependencies": {
         "@netlify/edge-functions": "^2.11.1",
@@ -2482,12 +2481,6 @@
         "@types/sizzle": "*"
       }
     },
-    "node_modules/@types/js-yaml": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
-      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
-      "license": "MIT"
-    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -3170,6 +3163,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-shuffle": {
@@ -5279,6 +5273,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -8548,6 +8543,21 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -20,19 +20,18 @@
   "dependencies": {
     "@google/model-viewer": "^4.3.1",
     "@types/html2canvas": "^0.5.35",
-    "@types/js-yaml": "^4.0.9",
     "aframe": "^1.7.1",
     "aframe-extras": "^7.6.0",
     "firebase": "^12.6.0",
     "html2canvas": "^1.4.1",
-    "js-yaml": "^4.1.0",
     "jszip": "^3.10.1",
     "qrcode": "^1.5.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-helmet": "^6.1.0",
     "react-markdown": "^9.0.1",
-    "react-router": "^7.1.0"
+    "react-router": "^7.1.0",
+    "yaml": "^2.8.1"
   },
   "devDependencies": {
     "@netlify/edge-functions": "^2.11.1",

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1,4 +1,4 @@
-import * as yaml from 'js-yaml';
+import * as yaml from './yaml.ts';
 
 // Firebase REST API configuration
 const FIREBASE_PROJECT_ID = 'poppenhu-is';
@@ -240,7 +240,7 @@ export interface Item {
 }
 `;
 
-import { PS2_SAVE_ICONS_COLLECTION } from './ps2-archive';
+import { PS2_SAVE_ICONS_COLLECTION } from './ps2-archive.ts';
 
 export const FIRST_PARTY_MANIFEST: Manifest = [
   // {

--- a/src/routes/CollectionPage.tsx
+++ b/src/routes/CollectionPage.tsx
@@ -7,7 +7,7 @@ import Markdown from "react-markdown";
 import { HelmetMeta } from '../components/HelmetMeta';
 import { QueryPreservingLink } from '../components/QueryPreservingLink';
 import { PageHeader } from '../components/PageHeader';
-import * as yaml from 'js-yaml';
+import * as yaml from '../yaml.ts';
 
 const ITEMS_PER_PAGE = 30;
 

--- a/src/routes/ItemPage.tsx
+++ b/src/routes/ItemPage.tsx
@@ -14,7 +14,7 @@ import { QrCode } from "../components/QrCode";
 import { AFrameScene } from "../components/AFrameScene";
 import { Receipt } from "../components/Receipt";
 import { DescriptionList } from "../components/DescriptionList";
-import * as yaml from 'js-yaml';
+import * as yaml from '../yaml.ts';
 
 export const loader = loadItem
 

--- a/src/routes/UserPage.tsx
+++ b/src/routes/UserPage.tsx
@@ -8,7 +8,7 @@ import Markdown from "react-markdown";
 import { QueryPreservingLink } from "../components/QueryPreservingLink";
 import { HelmetMeta } from "../components/HelmetMeta";
 import { PageHeader } from "../components/PageHeader";
-import * as yaml from 'js-yaml';
+import * as yaml from '../yaml.ts';
 
 export const loader = loadUser;
 

--- a/src/yaml.test.ts
+++ b/src/yaml.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { dump, load } from './yaml.ts';
+
+describe('yaml helpers', () => {
+  it('parses simple item frontmatter', () => {
+    const parsed = load(`
+manufacturer: Debbie
+captureMethod: LiDAR
+material:
+  - clay
+  - glaze
+`);
+    expect(parsed).toEqual({
+      manufacturer: 'Debbie',
+      captureMethod: 'LiDAR',
+      material: ['clay', 'glaze'],
+    });
+  });
+
+  it('round-trips an item-like object for edit links', () => {
+    const item = {
+      id: 'bear',
+      name: 'bear',
+      model: '/assets/goldens/bear.glb',
+      manufacturer: 'Leaonie',
+    };
+    const parsed = load(dump(item));
+    expect(parsed).toEqual(item);
+  });
+});

--- a/src/yaml.ts
+++ b/src/yaml.ts
@@ -1,0 +1,14 @@
+import YAML from 'yaml';
+
+/**
+ * Edge-safe YAML helpers.
+ * js-yaml is CommonJS and fails Netlify's Deno edge bundler.
+ * Import the default export so both the CJS and ESM builds work.
+ */
+export function load(source: string): unknown {
+  return YAML.parse(source);
+}
+
+export function dump(value: unknown): string {
+  return YAML.stringify(value);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The production deploy at https://app.netlify.com/projects/poppenhuis/deploys/6a9b4b1e27cc640008b92812 failed while packaging the `transform` edge function:

```
There was an error when loading the 'js-yaml' npm module.
Support for npm modules in edge functions is an experimental feature.
```

`netlify/edge-functions/transform.ts` imports `loadUser` / `loadCollection` / `loadItem` from `src/manifest.ts`, which imported CommonJS `js-yaml`. Netlify's Deno edge bundler cannot load that package, so the site build never reached deploy.

## Fix

- Replace `js-yaml` with the `yaml` package and a small `src/yaml.ts` helper that uses the default export (works with both the CJS and ESM builds).
- Use `.ts` extensions on local imports that the edge graph resolves (`./yaml.ts`, `./ps2-archive.ts`).
- Keep the same `load` / `dump` call sites used for Are.na description frontmatter and the GitHub “edit?” YAML templates.

## Verification

- `npm test -- --run` — 22 tests passed, including new YAML parse/dump coverage
- `npm run build` — `tsc && vite build` succeeded
- Local `@netlify/edge-bundler` run produced a successful `transform` bundle (this is the step that failed on Netlify)
- `npm run lint` still fails because the repo has no ESLint config (pre-existing)

Netlify deploy previews on this branch should get past Edge Functions bundling.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8812a5f6-fc47-4478-ad91-533a8cf73e56?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8812a5f6-fc47-4478-ad91-533a8cf73e56&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

